### PR TITLE
ci: fix update version to update main.go

### DIFF
--- a/.github/workflows/update-api-version.yaml
+++ b/.github/workflows/update-api-version.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Update version in cmd/api/main.go
         run: |
-          sed -i "s/var version = \".*\"/var version = \"${{ steps.get_version.outputs.VERSION }}\"/" cmd/api/main.go
+          sed -i "s/const version = \".*\"/const version = \"${{ steps.get_version.outputs.VERSION }}\"/" cmd/api/main.go
 
       - name: Commit and push if changed
         run: |


### PR DESCRIPTION
The current workflow doesn't work because it is lacking the `const` which is defined in `main.go`