### PR TITLE
fix: correct typo maxRetires -> maxRetries

### DIFF
--- a/internal/mailer/mailer.go
+++ b/internal/mailer/mailer.go
@@ -4,7 +4,7 @@ import "embed"
 
 const (
 	FromName            = "GopherSocial"
-	maxRetires          = 3
+	maxRetries          = 3
 	UserWelcomeTemplate = "user_invitation.tmpl"
 )
 

--- a/internal/mailer/sendgrid.go
+++ b/internal/mailer/sendgrid.go
@@ -57,7 +57,7 @@ func (m *SendGridMailer) Send(templateFile, username, email string, data any, is
 	})
 
 	var retryErr error
-	for i := 0; i < maxRetires; i++ {
+	for i := 0; i < maxRetries; i++ {
 		response, retryErr := m.client.Send(message)
 		if retryErr != nil {
 			// exponential backoff
@@ -68,5 +68,5 @@ func (m *SendGridMailer) Send(templateFile, username, email string, data any, is
 		return response.StatusCode, nil
 	}
 
-	return -1, fmt.Errorf("failed to send email after %d attempt, error: %v", maxRetires, retryErr)
+	return -1, fmt.Errorf("failed to send email after %d attempt, error: %v", maxRetries, retryErr)
 }


### PR DESCRIPTION
## Description
Fix typo in constant name `maxRetires` → `maxRetries` across the mailer package.
